### PR TITLE
Bug 1751827 - Problems migrating services with serving-cert-secret-name annotation 

### DIFF
--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -13,12 +13,14 @@ import (
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/replicaset"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/replicationcontroller"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/route"
+	"github.com/fusor/openshift-velero-plugin/velero-plugins/secret"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/service"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/serviceaccount"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/statefulset"
 	veleroplugin "github.com/heptio/velero/pkg/plugin/framework"
 	"github.com/sirupsen/logrus"
 )
+
 func main() {
 	veleroplugin.NewServer().
 		RegisterBackupItemAction("openshift.io/01-common-backup-plugin", newCommonBackupPlugin).
@@ -37,6 +39,7 @@ func main() {
 		RegisterRestoreItemAction("openshift.io/15-service-restore-plugin", newServiceRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/16-cronjob-restore-plugin", newCronJobRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/17-buildconfig-restore-plugin", newBuildConfigRestorePlugin).
+		RegisterRestoreItemAction("openshift.io/18-secret-restore-plugin", newSecretRestorePlugin).
 		Serve()
 }
 
@@ -102,4 +105,8 @@ func newServiceAccountRestorePlugin(logger logrus.FieldLogger) (interface{}, err
 
 func newStatefulSetRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 	return &statefulset.RestorePlugin{Log: logger}, nil
+}
+
+func newSecretRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &secret.RestorePlugin{Log: logger}, nil
 }

--- a/velero-plugins/secret/restore.go
+++ b/velero-plugins/secret/restore.go
@@ -1,0 +1,49 @@
+package secret
+
+import (
+	"encoding/json"
+
+	"github.com/heptio/velero/pkg/plugin/velero"
+	"github.com/sirupsen/logrus"
+	corev1API "k8s.io/api/core/v1"
+)
+
+const (
+	serviceOriginAnnotation = "service.alpha.openshift.io/originating-service-name"
+)
+
+// RestorePlugin is a restore item action plugin for Velero
+type RestorePlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a velero.ResourceSelector that applies to secrets
+func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"secrets"},
+	}, nil
+}
+
+// Execute action for the restore plugin for the secret resource
+func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.Log.Info("[secret-restore] Entering Secret restore plugin")
+
+	secret := corev1API.Secret{}
+	itemMarshal, _ := json.Marshal(input.Item)
+	json.Unmarshal(itemMarshal, &secret)
+	p.Log.Infof("[secret-restore] Secret: %s", secret.Name)
+
+	// Don't restore secret if is owned by a service and has an `originating-service-name` annotation,
+	// as it will be recreated, according to https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#secrets-troubleshooting
+	// Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1751827
+
+	for annotation, value := range secret.GetAnnotations() {
+		if annotation != serviceOriginAnnotation {
+			continue
+		}
+		p.Log.Infof("[secret-restore] Skip secret %s restore, as it will be recreated by a service %s", secret.Name, value)
+		return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
+	}
+
+	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+}


### PR DESCRIPTION
Added restore plugin to exclude service generated secrets

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1751827