### PR TITLE
OADP-6675: Update Azure registry configuration for workload identity support

### DIFF
--- a/velero-plugins/imagestream/registry.go
+++ b/velero-plugins/imagestream/registry.go
@@ -23,13 +23,13 @@ const (
 	RegistryStorageS3RootdirectoryEnvVarKey         = "REGISTRY_STORAGE_S3_ROOTDIRECTORY"
 	RegistryStorageS3SkipverifyEnvVarKey            = "REGISTRY_STORAGE_S3_SKIPVERIFY"
 	// Azure registry env vars
-	RegistryStorageAzureContainerEnvVarKey       = "REGISTRY_STORAGE_AZURE_CONTAINER"
-	RegistryStorageAzureAccountnameEnvVarKey     = "REGISTRY_STORAGE_AZURE_ACCOUNTNAME"
-	RegistryStorageAzureAccountkeyEnvVarKey      = "REGISTRY_STORAGE_AZURE_ACCOUNTKEY"
-	RegistryStorageAzureSPNClientIDEnvVarKey     = "REGISTRY_STORAGE_AZURE_SPN_CLIENT_ID"
-	RegistryStorageAzureSPNClientSecretEnvVarKey = "REGISTRY_STORAGE_AZURE_SPN_CLIENT_SECRET"
-	RegistryStorageAzureSPNTenantIDEnvVarKey     = "REGISTRY_STORAGE_AZURE_SPN_TENANT_ID"
-	RegistryStorageAzureAADEndpointEnvVarKey     = "REGISTRY_STORAGE_AZURE_AAD_ENDPOINT"
+	RegistryStorageAzureContainerEnvVarKey           = "REGISTRY_STORAGE_AZURE_CONTAINER"
+	RegistryStorageAzureAccountnameEnvVarKey         = "REGISTRY_STORAGE_AZURE_ACCOUNTNAME"
+	RegistryStorageAzureAccountkeyEnvVarKey          = "REGISTRY_STORAGE_AZURE_ACCOUNTKEY"
+	RegistryStorageAzureCredentialsTypeEnvVarKey     = "REGISTRY_STORAGE_AZURE_CREDENTIALS_TYPE"
+	RegistryStorageAzureCredentialsClientIDEnvVarKey = "REGISTRY_STORAGE_AZURE_CREDENTIALS_CLIENTID"
+	RegistryStorageAzureCredentialsSecretEnvVarKey   = "REGISTRY_STORAGE_AZURE_CREDENTIALS_SECRET"
+	RegistryStorageAzureCredentialsTenantIDEnvVarKey = "REGISTRY_STORAGE_AZURE_CREDENTIALS_TENANTID"
 	// GCP registry env vars
 	RegistryStorageGCSBucket        = "REGISTRY_STORAGE_GCS_BUCKET"
 	RegistryStorageGCSKeyfile       = "REGISTRY_STORAGE_GCS_KEYFILE"
@@ -81,19 +81,19 @@ var cloudProviderEnvVarMap = map[string][]corev1.EnvVar{
 			Value: "",
 		},
 		{
-			Name:  RegistryStorageAzureAADEndpointEnvVarKey,
+			Name:  RegistryStorageAzureCredentialsTypeEnvVarKey,
 			Value: "",
 		},
 		{
-			Name:  RegistryStorageAzureSPNClientIDEnvVarKey,
+			Name:  RegistryStorageAzureCredentialsClientIDEnvVarKey,
 			Value: "",
 		},
 		{
-			Name:  RegistryStorageAzureSPNClientSecretEnvVarKey,
+			Name:  RegistryStorageAzureCredentialsSecretEnvVarKey,
 			Value: "",
 		},
 		{
-			Name:  RegistryStorageAzureSPNTenantIDEnvVarKey,
+			Name:  RegistryStorageAzureCredentialsTenantIDEnvVarKey,
 			Value: "",
 		},
 	},
@@ -126,9 +126,9 @@ func getAWSRegistryEnvVars(bsl *velerov1.BackupStorageLocation) ([]corev1.EnvVar
 	if bsl.Spec.Config == nil {
 		bsl.Spec.Config = make(map[string]string)
 	}
-	if bsl.Spec.Config[S3URL] == ""  && bsl.Spec.Config[Region] == "" {
+	if bsl.Spec.Config[S3URL] == "" && bsl.Spec.Config[Region] == "" {
 		var err error
-		bsl.Spec.Config[Region], err = GetBucketRegion(bsl.Spec.StorageType.ObjectStorage.Bucket)
+		bsl.Spec.Config[Region], err = GetBucketRegion(bsl.Spec.ObjectStorage.Bucket)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get bucket region")
 		}
@@ -146,7 +146,7 @@ func getAWSRegistryEnvVars(bsl *velerov1.BackupStorageLocation) ([]corev1.EnvVar
 		},
 		{
 			Name:  RegistryStorageS3BucketEnvVarKey,
-			Value: bsl.Spec.StorageType.ObjectStorage.Bucket,
+			Value: bsl.Spec.ObjectStorage.Bucket,
 		},
 		{
 			Name:  RegistryStorageS3RegionEnvVarKey,
@@ -199,7 +199,7 @@ func getAWSRegistryEnvVars(bsl *velerov1.BackupStorageLocation) ([]corev1.EnvVar
 func getBslSecretPath(bsl *velerov1.BackupStorageLocation) string {
 	var secretName, secretKey string
 	if bsl.Spec.Credential != nil {
-		secretName = bsl.Spec.Credential.LocalObjectReference.Name
+		secretName = bsl.Spec.Credential.Name
 		secretKey = bsl.Spec.Credential.Key
 	}
 	// if secretName or secretKey is not set, inherit from OADP defaults for each provider
@@ -216,44 +216,53 @@ func getAzureRegistryEnvVars(bsl *velerov1.BackupStorageLocation, azureEnvVars [
 	if bsl.Spec.Config == nil {
 		bsl.Spec.Config = make(map[string]string)
 	}
+	secretName := "oadp-" + bsl.Name + "-" + bsl.Spec.Provider + "-registry-secret"
+
 	for i := range azureEnvVars {
-		if azureEnvVars[i].Name == RegistryStorageAzureContainerEnvVarKey {
-			azureEnvVars[i].Value = bsl.Spec.StorageType.ObjectStorage.Bucket
-		}
+		switch azureEnvVars[i].Name {
+		case RegistryStorageAzureContainerEnvVarKey:
+			azureEnvVars[i].Value = bsl.Spec.ObjectStorage.Bucket
 
-		if azureEnvVars[i].Name == RegistryStorageAzureAccountnameEnvVarKey {
+		case RegistryStorageAzureAccountnameEnvVarKey:
 			azureEnvVars[i].Value = bsl.Spec.Config[StorageAccount]
-		}
 
-		if azureEnvVars[i].Name == RegistryStorageAzureAccountkeyEnvVarKey {
+		case RegistryStorageAzureAccountkeyEnvVarKey:
 			azureEnvVars[i].ValueFrom = &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + bsl.Name + "-" + bsl.Spec.Provider + "-registry-secret"},
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
 					Key:                  "storage_account_key",
 				},
 			}
-		}
-		if azureEnvVars[i].Name == RegistryStorageAzureSPNClientIDEnvVarKey {
+
+		case RegistryStorageAzureCredentialsTypeEnvVarKey:
+			// Get credentials type from secret
 			azureEnvVars[i].ValueFrom = &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + bsl.Name + "-" + bsl.Spec.Provider + "-registry-secret"},
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+					Key:                  "credentials_type",
+				},
+			}
+
+		case RegistryStorageAzureCredentialsClientIDEnvVarKey:
+			azureEnvVars[i].ValueFrom = &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
 					Key:                  "client_id_key",
 				},
 			}
-		}
 
-		if azureEnvVars[i].Name == RegistryStorageAzureSPNClientSecretEnvVarKey {
+		case RegistryStorageAzureCredentialsSecretEnvVarKey:
 			azureEnvVars[i].ValueFrom = &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + bsl.Name + "-" + bsl.Spec.Provider + "-registry-secret"},
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
 					Key:                  "client_secret_key",
 				},
 			}
-		}
-		if azureEnvVars[i].Name == RegistryStorageAzureSPNTenantIDEnvVarKey {
+
+		case RegistryStorageAzureCredentialsTenantIDEnvVarKey:
 			azureEnvVars[i].ValueFrom = &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + bsl.Name + "-" + bsl.Spec.Provider + "-registry-secret"},
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
 					Key:                  "tenant_id_key",
 				},
 			}
@@ -270,7 +279,7 @@ func getGCPRegistryEnvVars(bsl *velerov1.BackupStorageLocation) ([]corev1.EnvVar
 		},
 		{
 			Name:  RegistryStorageGCSBucket,
-			Value: bsl.Spec.StorageType.ObjectStorage.Bucket,
+			Value: bsl.Spec.ObjectStorage.Bucket,
 		},
 		{
 			Name:  RegistryStorageGCSKeyfile,

--- a/velero-plugins/imagestream/registry_test.go
+++ b/velero-plugins/imagestream/registry_test.go
@@ -118,7 +118,9 @@ var (
 web_identity_token_file=/var/run/secrets/some/path
 `),
 	}
+	// Azure registry secret data with shared_key authentication
 	azureRegistrySecretData = map[string][]byte{
+		"credentials_type":    []byte("shared_key"), // Valid values: shared_key, client_secret, default_credentials
 		"client_id_key":       []byte(""),
 		"client_secret_key":   []byte(""),
 		"resource_group_key":  []byte(""),
@@ -126,13 +128,25 @@ web_identity_token_file=/var/run/secrets/some/path
 		"subscription_id_key": []byte(""),
 		"tenant_id_key":       []byte(""),
 	}
+	// Azure registry secret data with service principal (client_secret) authentication
 	azureRegistrySPSecretData = map[string][]byte{
+		"credentials_type":    []byte("client_secret"), // Service principal authentication
 		"client_id_key":       []byte(testClientID),
 		"client_secret_key":   []byte(testClientSecret),
 		"resource_group_key":  []byte(testResourceGroup),
 		"storage_account_key": []byte(testStoragekey),
 		"subscription_id_key": []byte(testSubscriptionID),
 		"tenant_id_key":       []byte(testTenantID),
+	}
+	// Azure registry secret data with managed identity (default_credentials) authentication
+	azureRegistryManagedIdentitySecretData = map[string][]byte{
+		"credentials_type":    []byte("default_credentials"), // Managed identity/workload identity
+		"client_id_key":       []byte(testClientID),
+		"client_secret_key":   []byte(""),
+		"resource_group_key":  []byte(testResourceGroup),
+		"storage_account_key": []byte(testStoragekey),
+		"subscription_id_key": []byte(testSubscriptionID),
+		"tenant_id_key":       []byte(""),
 	}
 )
 
@@ -632,6 +646,44 @@ func Test_getAzureRegistryEnvVars(t *testing.T) {
 			wantProfile:  "test-sp-profile",
 			matchProfile: true,
 		},
+		{
+			name: "given azure bsl & managed identity credentials, appropriate env var for the container are returned",
+			bsl: &velerov1.BackupStorageLocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bsl",
+					Namespace: "test-ns",
+				},
+				Spec: velerov1.BackupStorageLocationSpec{
+					Provider: AzureProvider,
+					StorageType: velerov1.StorageType{
+						ObjectStorage: &velerov1.ObjectStorageLocation{
+							Bucket: "azure-bucket",
+						},
+					},
+					Config: map[string]string{
+						StorageAccount:   "velero-azure-account",
+						ResourceGroup:    testResourceGroup,
+						"subscriptionId": testSubscriptionID,
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials-azure",
+					Namespace: "test-ns",
+				},
+				Data: secretAzureData,
+			},
+			registrySecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "oadp-test-bsl-azure-registry-secret",
+					Namespace: "test-ns",
+				},
+				Data: azureRegistryManagedIdentitySecretData,
+			},
+			wantProfile:  "test-mi-profile",
+			matchProfile: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -658,11 +710,16 @@ func Test_getAzureRegistryEnvVars(t *testing.T) {
 					},
 				},
 				{
-					Name:  RegistryStorageAzureAADEndpointEnvVarKey,
-					Value: "",
+					Name: RegistryStorageAzureCredentialsTypeEnvVarKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
+							Key:                  "credentials_type",
+						},
+					},
 				},
 				{
-					Name: RegistryStorageAzureSPNClientIDEnvVarKey,
+					Name: RegistryStorageAzureCredentialsClientIDEnvVarKey,
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
@@ -671,7 +728,7 @@ func Test_getAzureRegistryEnvVars(t *testing.T) {
 					},
 				},
 				{
-					Name: RegistryStorageAzureSPNClientSecretEnvVarKey,
+					Name: RegistryStorageAzureCredentialsSecretEnvVarKey,
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
@@ -680,7 +737,7 @@ func Test_getAzureRegistryEnvVars(t *testing.T) {
 					},
 				},
 				{
-					Name: RegistryStorageAzureSPNTenantIDEnvVarKey,
+					Name: RegistryStorageAzureCredentialsTenantIDEnvVarKey,
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
@@ -713,11 +770,16 @@ func Test_getAzureRegistryEnvVars(t *testing.T) {
 						},
 					},
 					{
-						Name:  RegistryStorageAzureAADEndpointEnvVarKey,
-						Value: "",
+						Name: RegistryStorageAzureCredentialsTypeEnvVarKey,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
+								Key:                  "credentials_type",
+							},
+						},
 					},
 					{
-						Name: RegistryStorageAzureSPNClientIDEnvVarKey,
+						Name: RegistryStorageAzureCredentialsClientIDEnvVarKey,
 						ValueFrom: &corev1.EnvVarSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
@@ -726,7 +788,7 @@ func Test_getAzureRegistryEnvVars(t *testing.T) {
 						},
 					},
 					{
-						Name: RegistryStorageAzureSPNClientSecretEnvVarKey,
+						Name: RegistryStorageAzureCredentialsSecretEnvVarKey,
 						ValueFrom: &corev1.EnvVarSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
@@ -735,7 +797,68 @@ func Test_getAzureRegistryEnvVars(t *testing.T) {
 						},
 					},
 					{
-						Name: RegistryStorageAzureSPNTenantIDEnvVarKey,
+						Name: RegistryStorageAzureCredentialsTenantIDEnvVarKey,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
+								Key:                  "tenant_id_key",
+							},
+						},
+					},
+				}
+			}
+			if tt.wantProfile == "test-mi-profile" {
+				tt.wantRegistryContainerEnvVar = []corev1.EnvVar{
+					{
+						Name:  RegistryStorageEnvVarKey,
+						Value: Azure,
+					},
+					{
+						Name:  RegistryStorageAzureContainerEnvVarKey,
+						Value: "azure-bucket",
+					},
+					{
+						Name:  RegistryStorageAzureAccountnameEnvVarKey,
+						Value: "velero-azure-account",
+					},
+					{
+						Name: RegistryStorageAzureAccountkeyEnvVarKey,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
+								Key:                  "storage_account_key",
+							},
+						},
+					},
+					{
+						Name: RegistryStorageAzureCredentialsTypeEnvVarKey,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
+								Key:                  "credentials_type",
+							},
+						},
+					},
+					{
+						Name: RegistryStorageAzureCredentialsClientIDEnvVarKey,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
+								Key:                  "client_id_key",
+							},
+						},
+					},
+					{
+						Name: RegistryStorageAzureCredentialsSecretEnvVarKey,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},
+								Key:                  "client_secret_key",
+							},
+						},
+					},
+					{
+						Name: RegistryStorageAzureCredentialsTenantIDEnvVarKey,
 						ValueFrom: &corev1.EnvVarSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{Name: "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret"},


### PR DESCRIPTION
## Why the changes were made

This PR updates the Azure registry configuration to support workload identity authentication. These changes are required to work with the updated OADP operator that now supports Azure workload identity for the image registry component.

Without these changes, the openshift-velero-plugin cannot consume the new secret format created by the OADP operator when using Azure workload identity.

## How to test the changes made

### Prerequisites
- OADP operator with Azure workload identity support (PR #1952)
- OpenShift cluster with Azure workload identity configured
- Test instructions follow those in the OADP operator PR

### Testing Steps

1. **Deploy OADP operator** with Azure workload identity support from PR #1952

2. **Build and deploy this version of openshift-velero-plugin:**
```bash
# Build the plugin
make build

# Update the velero deployment to use the new plugin version
oc set image deployment/velero -n openshift-adp \
  velero=<your-registry>/openshift-velero-plugin:latest
```

3. **Verify secret consumption:**
```bash
# Check that the registry secret is created with new format
oc get secret -n openshift-adp oadp-<bsl-name>-azure-registry-secret -o yaml

# Verify the secret contains the new credential keys:
# - credentials_type (should be "default_credentials" for workload identity)
# - client_id_key  
# - client_secret_key (empty for workload identity)
# - tenant_id_key

# Verify Velero has Azure workload identity env vars
oc exec -n openshift-adp deployment/velero -- env | grep AZURE
# Should show: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_FEDERATED_TOKEN_FILE
```

4. **Test image backup/restore** following the test plan in OADP operator PR #1952

### Verification Points
- [ ] Plugin correctly reads Azure credentials from new secret format
- [ ] Environment variables are properly mapped (CREDENTIALS_* instead of SPN_*)
- [ ] Registry authentication succeeds with workload identity
- [ ] Image backup and restore operations complete successfully
- [ ] No errors related to missing SPN environment variables

## Technical Details

### Azure Workload Identity Environment Setup

The OADP operator injects Azure workload identity environment variables into the Velero container through a secret (`azure-workload-identity-env`). This secret contains:
- `AZURE_CLIENT_ID`: The managed identity client ID
- `AZURE_TENANT_ID`: The Azure tenant ID  
- `AZURE_FEDERATED_TOKEN_FILE`: Path to the federated token (`/var/run/secrets/openshift/serviceaccount/token`)

These environment variables are injected into the Velero deployment using `envFrom` (see oadp-operator `internal/controller/velero.go:642-655`), ensuring they're available to both Velero and its plugins.

### Registry Authentication with Workload Identity

The registry component (docker-distribution) supports Azure AD authentication through the `default_credentials` type. When this type is set in the registry secret, the Azure storage driver:

1. Uses the Azure SDK's `DefaultAzureCredential`
2. Automatically detects the workload identity environment variables (inherited from Velero container)
3. Reads the federated token from the mounted service account token path
4. Exchanges it for Azure AD tokens
5. Authenticates to Azure Blob Storage

The plugin doesn't need to explicitly handle `AZURE_FEDERATED_TOKEN_FILE` because:
- It's already set in the Velero container environment
- The registry process inherits the environment from its parent container
- The Azure SDK automatically uses these variables for authentication

## Changes Summary

- Replaced deprecated `SPN_*` environment variable constants with `CREDENTIALS_*` format
- Updated `getAzureRegistryEnvVars()` to reference new secret keys matching OADP operator
- Added support for `credentials_type` field from secret
- Fixed BSL spec references (using `ObjectStorage` instead of `StorageType.ObjectStorage`)

## Dependencies

**This PR depends on:** openshift/oadp-operator#1952

Both PRs must be merged together for Azure workload identity support to function properly. The OADP operator PR handles creating and injecting the workload identity environment variables, while this PR ensures the plugin correctly consumes the new secret format.

🤖 Generated with [Claude Code](https://claude.ai/code)