### PR TITLE
fix: use PVC name instead of GenerateName for VMFR restores

### DIFF
--- a/velero-plugins/pvc/vmfr_restore.go
+++ b/velero-plugins/pvc/vmfr_restore.go
@@ -1,27 +1,36 @@
 package pvc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	corev1API "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/rand"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 const (
 	// VMFRRestoreAnnotation is the annotation that triggers VMFR PVC renaming
 	VMFRRestoreAnnotation = "oadp.openshift.io/vmfr-restore"
-	// VMFRBackupLabel identifies which backup a restored PVC came from
-	VMFRBackupLabel = "oadp.openshift.io/vmfr-backup"
-	// VMFROriginalNameLabel stores the original PVC name before VMFR renaming
-	VMFROriginalNameLabel = "oadp.openshift.io/vmfr-original-name"
+	// VMFRBackupAnnotation identifies which backup a restored PVC came from
+	VMFRBackupAnnotation = "oadp.openshift.io/vmfr-backup"
+	// VMFROriginalNameAnnotation stores the original PVC name before VMFR renaming
+	VMFROriginalNameAnnotation = "oadp.openshift.io/vmfr-original-name"
+	// VMFRPrimaryLabel identifies the primary (first restored) PVC with original name
+	VMFRPrimaryLabel = "oadp.openshift.io/vmfr-primary"
 )
 
 // VMFRRestorePlugin is a restore item action plugin for VMFR PVC renaming
 type VMFRRestorePlugin struct {
-	Log logrus.FieldLogger
+	Log        logrus.FieldLogger
+	CoreClient corev1client.CoreV1Interface
 }
 
 // AppliesTo returns a velero.ResourceSelector that applies to PVCs
@@ -51,25 +60,85 @@ func (p *VMFRRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput)
 		return nil, fmt.Errorf("[vmfr-pvc-restore] error unmarshaling PVC: %v", err)
 	}
 
-	// Generate unique PVC name using GenerateName to avoid collisions.
-	// The Kubernetes API server will automatically truncate long prefixes (>58 chars)
-	// and append a 5-character random suffix to ensure uniqueness.
 	originalName := pvc.Name
 	backupName := input.Restore.Spec.BackupName
-	generateNamePrefix := fmt.Sprintf("%s-%s-", backupName, originalName)
+	namespace := input.Restore.Spec.NamespaceMapping[pvc.Namespace]
+	if namespace == "" {
+		namespace = pvc.Namespace
+	}
 
-	p.Log.Infof("[vmfr-pvc-restore] Setting GenerateName for PVC from %s to %s for VMFR multi-backup restore", originalName, generateNamePrefix)
+	p.Log.Infof("[vmfr-pvc-restore] Processing PVC: originalName=%s, pvc.Namespace=%s, mappedNamespace=%s, backupName=%s",
+		originalName, pvc.Namespace, namespace, backupName)
 
-	// Use GenerateName instead of Name to let Kubernetes generate unique suffix
-	pvc.GenerateName = generateNamePrefix
-	pvc.Name = ""
+	// Get Kubernetes client to check if PVC already exists
+	coreClient := p.CoreClient
+	if coreClient == nil {
+		// If not injected (for production use), get from clients package
+		coreClient, err = clients.CoreClient()
+		if err != nil {
+			return nil, fmt.Errorf("[vmfr-pvc-restore] error getting Kubernetes client: %v", err)
+		}
+	}
 
-	// Add tracking labels for VMFR management
+	// Check if PVC with original name already exists in the target namespace
+	p.Log.Infof("[vmfr-pvc-restore] Checking if PVC %s exists in namespace %s", originalName, namespace)
+	_, err = coreClient.PersistentVolumeClaims(namespace).Get(context.Background(), originalName, metav1.GetOptions{})
+	pvcExists := err == nil
+	if err != nil && !errors.IsNotFound(err) {
+		// Unexpected error (not "not found")
+		return nil, fmt.Errorf("[vmfr-pvc-restore] error checking if PVC exists: %v", err)
+	}
+	p.Log.Infof("[vmfr-pvc-restore] PVC %s in namespace %s exists: %v (error: %v)", originalName, namespace, pvcExists, err)
+
+	// Initialize annotations and labels
+	if pvc.Annotations == nil {
+		pvc.Annotations = make(map[string]string)
+	}
 	if pvc.Labels == nil {
 		pvc.Labels = make(map[string]string)
 	}
-	pvc.Labels[VMFRBackupLabel] = backupName
-	pvc.Labels[VMFROriginalNameLabel] = originalName
+
+	if !pvcExists {
+		// First restore: Keep original name, mark as primary
+		p.Log.Infof("[vmfr-pvc-restore] PVC %s does not exist, keeping original name as primary", originalName)
+		pvc.Name = originalName
+		pvc.GenerateName = ""
+		pvc.Labels[VMFRPrimaryLabel] = "true"
+		pvc.Annotations[VMFRBackupAnnotation] = backupName
+		pvc.Annotations[VMFROriginalNameAnnotation] = originalName
+	} else {
+		// Subsequent restore: PVC already exists, generate unique name
+		// Pattern: {backup-name}-{10-char-random-suffix}
+		p.Log.Infof("[vmfr-pvc-restore] PVC %s already exists, generating unique name for multi-backup restore", originalName)
+
+		// Generate 10-character random suffix for strong collision resistance
+		suffix := rand.String(10)
+
+		// Kubernetes resource names must be <= 253 characters (DNS-1123 subdomain)
+		// Format: backup-name + "-" + 10-char-suffix
+		maxLen := 253
+		maxBackupNameLen := maxLen - 1 - 10 // 242 chars for backup name
+
+		truncatedBackupName := backupName
+		if len(backupName) > maxBackupNameLen {
+			truncatedBackupName = backupName[:maxBackupNameLen]
+			p.Log.Warnf("[vmfr-pvc-restore] Backup name truncated from %d to %d chars", len(backupName), maxBackupNameLen)
+		}
+
+		newPVCName := fmt.Sprintf("%s-%s", truncatedBackupName, suffix)
+		pvc.Name = newPVCName
+		pvc.GenerateName = ""
+
+		p.Log.Infof("[vmfr-pvc-restore] Renamed PVC from %s to %s for VMFR multi-backup restore", originalName, newPVCName)
+
+		// Mark as non-primary and store original name
+		pvc.Labels[VMFRPrimaryLabel] = "false"
+		pvc.Annotations[VMFRBackupAnnotation] = backupName
+		pvc.Annotations[VMFROriginalNameAnnotation] = originalName
+	}
+
+	// Add backup label for filtering (both primary and non-primary)
+	pvc.Labels[VMFRBackupAnnotation] = backupName
 
 	// Convert back to unstructured
 	var out map[string]interface{}

--- a/velero-plugins/pvc/vmfr_restore_test.go
+++ b/velero-plugins/pvc/vmfr_restore_test.go
@@ -1,82 +1,215 @@
 package pvc
 
 import (
-	"fmt"
+	"context"
+	"regexp"
+	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/util/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1API "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
+func TestVMFRRestorePluginAppliesTo(t *testing.T) {
+	restorePlugin := &VMFRRestorePlugin{Log: test.NewLogger()}
+	actual, err := restorePlugin.AppliesTo()
+	require.NoError(t, err)
+	assert.Equal(t, velero.ResourceSelector{IncludedResources: []string{"persistentvolumeclaims"}}, actual)
+}
+
 func TestVMFRRestorePlugin_Execute(t *testing.T) {
+	// Setup envtest environment
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	require.NoError(t, err)
+	defer testEnv.Stop()
+
+	// Initialize clients using envtest config
+	coreClient, err := clients.CoreClientFromConfig(cfg)
+	require.NoError(t, err)
+
 	tests := []struct {
-		name                     string
-		hasVMFRAnnotation        bool
-		restoreName              string
-		backupName               string
-		pvcName                  string
-		expectedGenerateNamePrefix string
-		expectedName             string
-		expectedLabels           map[string]string
+		name                 string
+		hasVMFRAnnotation    bool
+		restoreName          string
+		backupName           string
+		pvcName              string
+		pvcNamespace         string
+		pvcAlreadyExists     bool // Simulate existing PVC with same name
+		expectedNamePattern  string // Regex pattern since suffix is random
+		expectedMaxLen       int
+		shouldHaveSuffix     bool
+		expectedAnnotations  map[string]string
+		expectedLabels       map[string]string
 	}{
 		{
-			name:                     "VMFR restore with annotation should use GenerateName",
-			hasVMFRAnnotation:        true,
-			restoreName:              "vmfr-my-instance-backup-20250101",
-			backupName:               "backup-20250101",
-			pvcName:                  "my-app-pvc",
-			expectedGenerateNamePrefix: "backup-20250101-my-app-pvc-",
-			expectedName:             "", // Name should be cleared when using GenerateName
+			name:              "First VMFR restore should keep original name and mark as primary",
+			hasVMFRAnnotation: true,
+			restoreName:       "vmfr-my-instance-backup-20250101",
+			backupName:        "backup-20250101",
+			pvcName:           "my-app-pvc",
+			pvcNamespace:      "test-ns",
+			pvcAlreadyExists:  false, // First restore
+			expectedNamePattern: `^my-app-pvc$`, // Keep original name
+			expectedMaxLen:      253,
+			shouldHaveSuffix:    false,
+			expectedAnnotations: map[string]string{
+				VMFRBackupAnnotation: "backup-20250101",
+			},
 			expectedLabels: map[string]string{
-				VMFRBackupLabel:       "backup-20250101",
-				VMFROriginalNameLabel: "my-app-pvc",
+				VMFRBackupAnnotation: "backup-20250101",
+				VMFRPrimaryLabel:     "true",
 			},
 		},
 		{
-			name:                     "Non-VMFR restore should not modify PVC",
-			hasVMFRAnnotation:        false,
-			restoreName:              "regular-restore",
-			backupName:               "backup-20250101",
-			pvcName:                  "my-app-pvc",
-			expectedGenerateNamePrefix: "",
-			expectedName:             "my-app-pvc",
-			expectedLabels:           map[string]string{},
+			name:              "Subsequent VMFR restore should rename with suffix when PVC exists",
+			hasVMFRAnnotation: true,
+			restoreName:       "vmfr-my-instance-backup-20250115",
+			backupName:        "backup-20250115",
+			pvcName:           "my-app-pvc",
+			pvcNamespace:      "test-ns",
+			pvcAlreadyExists:  true, // PVC already exists from first restore
+			expectedNamePattern: `^backup-20250115-[a-z0-9]{10}$`, // Renamed
+			expectedMaxLen:      253,
+			shouldHaveSuffix:    true,
+			expectedAnnotations: map[string]string{
+				VMFRBackupAnnotation:       "backup-20250115",
+				VMFROriginalNameAnnotation: "my-app-pvc",
+			},
+			expectedLabels: map[string]string{
+				VMFRBackupAnnotation: "backup-20250115",
+				VMFRPrimaryLabel:     "false",
+			},
 		},
 		{
-			name:                     "VMFR restore with very long names passes full prefix to K8s",
-			hasVMFRAnnotation:        true,
-			restoreName:              "vmfr-long-restore",
-			backupName:               "backup-for-production-environment-disaster-recovery-scenario-2024-12-01-full-system-backup-including-all-persistent-data-and-configuration-files-with-retention-policy",
-			pvcName:                  "application-database-persistent-volume-claim-for-postgresql-primary-instance-with-high-availability-configuration-and-automated-backup-scheduling",
-			expectedGenerateNamePrefix: "backup-for-production-environment-disaster-recovery-scenario-2024-12-01-full-system-backup-including-all-persistent-data-and-configuration-files-with-retention-policy-application-database-persistent-volume-claim-for-postgresql-primary-instance-with-high-availability-configuration-and-automated-backup-scheduling-",
-			expectedName:             "", // Name should be cleared when using GenerateName
+			name:                 "Non-VMFR restore should not modify PVC",
+			hasVMFRAnnotation:    false,
+			restoreName:          "regular-restore",
+			backupName:           "backup-20250101",
+			pvcName:              "my-app-pvc",
+			pvcNamespace:         "test-ns",
+			pvcAlreadyExists:     false,
+			expectedNamePattern:  `^my-app-pvc$`,
+			expectedMaxLen:       253,
+			shouldHaveSuffix:     false,
+			expectedAnnotations:  map[string]string{},
+			expectedLabels:       map[string]string{},
+		},
+		{
+			name:              "VMFR restore with very long backup name truncates when renaming",
+			hasVMFRAnnotation: true,
+			restoreName:       "vmfr-long-restore",
+			backupName:        "backup-for-production-environment-disaster-recovery-scenario-2024-12-01-full-system-backup-including-all-persistent-data-and-configuration-files-with-retention-policy",
+			pvcName:           "my-app-pvc",
+			pvcNamespace:      "test-ns",
+			pvcAlreadyExists:  true, // Force renaming
+			// Should have truncated backup name (242 chars max) and 10-char suffix
+			expectedNamePattern: `^backup-for-production-environment-disaster-recovery-scenario-2024-12-01-full-system-backup-including-all-persistent-data-and-configuration-files-with-retention-policy-[a-z0-9]{10}$`,
+			expectedMaxLen:      253,
+			shouldHaveSuffix:    true,
+			expectedAnnotations: map[string]string{
+				VMFRBackupAnnotation:       "backup-for-production-environment-disaster-recovery-scenario-2024-12-01-full-system-backup-including-all-persistent-data-and-configuration-files-with-retention-policy",
+				VMFROriginalNameAnnotation: "my-app-pvc",
+			},
 			expectedLabels: map[string]string{
-				VMFRBackupLabel:       "backup-for-production-environment-disaster-recovery-scenario-2024-12-01-full-system-backup-including-all-persistent-data-and-configuration-files-with-retention-policy",
-				VMFROriginalNameLabel: "application-database-persistent-volume-claim-for-postgresql-primary-instance-with-high-availability-configuration-and-automated-backup-scheduling",
+				VMFRBackupAnnotation: "backup-for-production-environment-disaster-recovery-scenario-2024-12-01-full-system-backup-including-all-persistent-data-and-configuration-files-with-retention-policy",
+				VMFRPrimaryLabel:     "false",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create test PVC
+			// Create namespace for this test
+			_, err := coreClient.Namespaces().Create(context.Background(), &corev1API.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tt.pvcNamespace,
+				},
+			}, metav1.CreateOptions{})
+			if k8serrors.IsAlreadyExists(err) {
+				t.Logf("namespace %s already exists, which is fine for testing", tt.pvcNamespace)
+				err = nil
+			}
+			require.NoError(t, err)
+
+			// Clean up any existing PVC with the same name from previous tests
+			existingPVC, err := coreClient.PersistentVolumeClaims(tt.pvcNamespace).Get(context.Background(), tt.pvcName, metav1.GetOptions{})
+			if err == nil {
+				// Remove finalizers to allow immediate deletion in envtest
+				existingPVC.Finalizers = nil
+				_, err = coreClient.PersistentVolumeClaims(tt.pvcNamespace).Update(context.Background(), existingPVC, metav1.UpdateOptions{})
+				require.NoError(t, err)
+
+				// Delete the PVC (should be immediate with finalizers removed)
+				err = coreClient.PersistentVolumeClaims(tt.pvcNamespace).Delete(context.Background(), tt.pvcName, metav1.DeleteOptions{})
+				require.NoError(t, err)
+			} else if !k8serrors.IsNotFound(err) {
+				require.NoError(t, err)
+			}
+
+			// If test requires existing PVC, create it
+			if tt.pvcAlreadyExists {
+				_, err := coreClient.PersistentVolumeClaims(tt.pvcNamespace).Create(context.Background(), &corev1API.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.pvcName,
+						Namespace: tt.pvcNamespace,
+					},
+					Spec: corev1API.PersistentVolumeClaimSpec{
+						AccessModes: []corev1API.PersistentVolumeAccessMode{corev1API.ReadWriteOnce},
+						Resources: corev1API.VolumeResourceRequirements{
+							Requests: corev1API.ResourceList{
+								corev1API.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				}, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			// Create test PVC (from backup)
 			pvc := &corev1API.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: tt.pvcName,
+					Name:      tt.pvcName,
+					Namespace: tt.pvcNamespace,
 				},
 				Spec: corev1API.PersistentVolumeClaimSpec{
 					AccessModes: []corev1API.PersistentVolumeAccessMode{corev1API.ReadWriteOnce},
+					Resources: corev1API.VolumeResourceRequirements{
+						Requests: corev1API.ResourceList{
+							corev1API.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
 				},
 			}
 
-			pvcUnstructured, err := toUnstructured(pvc)
-			if err != nil {
-				t.Fatalf("Failed to convert PVC to unstructured: %v", err)
+			// Convert PVC to unstructured for plugin input
+			pvcMap := map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "PersistentVolumeClaim",
+				"metadata": map[string]interface{}{
+					"name":      pvc.Name,
+					"namespace": pvc.Namespace,
+				},
+				"spec": map[string]interface{}{
+					"accessModes": []interface{}{"ReadWriteOnce"},
+					"resources": map[string]interface{}{
+						"requests": map[string]interface{}{
+							"storage": "1Gi",
+						},
+					},
+				},
 			}
+			pvcUnstructured := &unstructured.Unstructured{Object: pvcMap}
 
 			// Create test restore
 			restore := &velerov1api.Restore{
@@ -84,7 +217,8 @@ func TestVMFRRestorePlugin_Execute(t *testing.T) {
 					Name: tt.restoreName,
 				},
 				Spec: velerov1api.RestoreSpec{
-					BackupName: tt.backupName,
+					BackupName:       tt.backupName,
+					NamespaceMapping: map[string]string{},
 				},
 			}
 
@@ -102,69 +236,55 @@ func TestVMFRRestorePlugin_Execute(t *testing.T) {
 
 			// Execute plugin
 			plugin := &VMFRRestorePlugin{
-				Log: logrus.NewEntry(logrus.New()),
+				Log:        test.NewLogger(),
+				CoreClient: coreClient,
 			}
 			output, err := plugin.Execute(input)
-			if err != nil {
-				t.Fatalf("Plugin execution failed: %v", err)
-			}
+			require.NoError(t, err)
 
-			// Verify results
-			resultPVC := &corev1API.PersistentVolumeClaim{}
+			// Verify results - convert unstructured back to PVC
 			updatedUnstructured, ok := output.UpdatedItem.(*unstructured.Unstructured)
-			if !ok {
-				t.Fatalf("Expected *unstructured.Unstructured, got %T", output.UpdatedItem)
-			}
-			err = fromUnstructured(updatedUnstructured, resultPVC)
-			if err != nil {
-				t.Fatalf("Failed to convert result to PVC: %v", err)
+			require.True(t, ok, "Expected *unstructured.Unstructured, got %T", output.UpdatedItem)
+
+			resultName := updatedUnstructured.GetName()
+			resultLabels := updatedUnstructured.GetLabels()
+			resultAnnotations := updatedUnstructured.GetAnnotations()
+			resultGenerateName := updatedUnstructured.GetGenerateName()
+
+			// Check PVC name matches pattern
+			matched, err := regexp.MatchString(tt.expectedNamePattern, resultName)
+			require.NoError(t, err, "Invalid regex pattern")
+			assert.True(t, matched, "PVC name %s does not match expected pattern %s", resultName, tt.expectedNamePattern)
+
+			// Check name length is within limit
+			assert.LessOrEqual(t, len(resultName), tt.expectedMaxLen, "PVC name length exceeds maximum")
+
+			// Check GenerateName is cleared
+			assert.Empty(t, resultGenerateName, "Expected PVC GenerateName to be empty")
+
+			// Check suffix is present for VMFR restores
+			if tt.shouldHaveSuffix {
+				parts := strings.Split(resultName, "-")
+				require.GreaterOrEqual(t, len(parts), 2, "Expected PVC name to have suffix")
+				suffix := parts[len(parts)-1]
+				assert.Equal(t, 10, len(suffix), "Expected 10-character suffix")
+				matched, _ := regexp.MatchString(`^[a-z0-9]{10}$`, suffix)
+				assert.True(t, matched, "Expected alphanumeric 10-character suffix, got %s", suffix)
 			}
 
-			// Check PVC name and GenerateName
-			if resultPVC.Name != tt.expectedName {
-				t.Errorf("Expected PVC name %s, got %s", tt.expectedName, resultPVC.Name)
-			}
-			if resultPVC.GenerateName != tt.expectedGenerateNamePrefix {
-				t.Errorf("Expected PVC GenerateName %s, got %s", tt.expectedGenerateNamePrefix, resultPVC.GenerateName)
+			// Check annotations
+			for expectedKey, expectedValue := range tt.expectedAnnotations {
+				actualValue, exists := resultAnnotations[expectedKey]
+				assert.True(t, exists, "Expected annotation %s to exist", expectedKey)
+				assert.Equal(t, expectedValue, actualValue, "Annotation %s value mismatch", expectedKey)
 			}
 
 			// Check labels
 			for expectedKey, expectedValue := range tt.expectedLabels {
-				if actualValue, exists := resultPVC.Labels[expectedKey]; !exists || actualValue != expectedValue {
-					t.Errorf("Expected label %s=%s, got %s=%s (exists: %v)", expectedKey, expectedValue, expectedKey, actualValue, exists)
-				}
+				actualValue, exists := resultLabels[expectedKey]
+				assert.True(t, exists, "Expected label %s to exist", expectedKey)
+				assert.Equal(t, expectedValue, actualValue, "Label %s value mismatch", expectedKey)
 			}
 		})
 	}
-}
-
-
-// Helper functions for testing
-func toUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
-	unstructuredObj := &unstructured.Unstructured{}
-	unstructuredObj.Object = make(map[string]interface{})
-
-	// Simple conversion for testing - in real usage, use proper serialization
-	if pvc, ok := obj.(*corev1API.PersistentVolumeClaim); ok {
-		unstructuredObj.SetName(pvc.Name)
-		unstructuredObj.SetNamespace(pvc.Namespace)
-		unstructuredObj.SetKind("PersistentVolumeClaim")
-		unstructuredObj.SetAPIVersion("v1")
-		return unstructuredObj, nil
-	}
-
-	return nil, fmt.Errorf("unsupported object type")
-}
-
-func fromUnstructured(u *unstructured.Unstructured, obj interface{}) error {
-	// Simple conversion for testing
-	if pvc, ok := obj.(*corev1API.PersistentVolumeClaim); ok {
-		pvc.Name = u.GetName()
-		pvc.GenerateName = u.GetGenerateName()
-		pvc.Namespace = u.GetNamespace()
-		pvc.Labels = u.GetLabels()
-		return nil
-	}
-
-	return fmt.Errorf("unsupported object type")
 }


### PR DESCRIPTION
Velero expects
- the PVC name must exists in the resulting namespace under the same name as it's original one.
- the name field to be populated, otherwise the restore goes into PartiallyFailed status. Generate the full PVC name with a random suffix instead of using GenerateName.

With the above, we first preserve the PVC name and any subsequent restored PVC under same name will get new name.

Convert Labels to Annotations
 Annotations don't have the 63-character limit that labels do
  - This fixes the issue where very long backup/PVC names would fail validation and Restore.