### PR TITLE
Migrate away from deprecated ioutil

### DIFF
--- a/velero-plugins/util/test/test_logger.go
+++ b/velero-plugins/util/test/test_logger.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/sirupsen/logrus"
 )
@@ -9,6 +9,6 @@ import (
 // NewLogger initialize test logger
 func NewLogger() logrus.FieldLogger {
 	logger := logrus.New()
-	logger.Out = ioutil.Discard
+	logger.Out = io.Discard
 	return logrus.NewEntry(logger)
 }


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code for compatibility with newer Go versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->