### PR TITLE
OADP-7132: Synchronize access to SCC map in SA plugin

### DIFF
--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -177,7 +177,7 @@ func newClusterRoleBindingRestorePlugin(logger logrus.FieldLogger) (interface{},
 }
 
 func newServiceAccountBackupPlugin(logger logrus.FieldLogger) (interface{}, error) {
-	saBackupPlugin := &serviceaccount.BackupPlugin{Log: logger}
+	saBackupPlugin := &serviceaccount.BackupPlugin{Log: logger, SCCCache: &serviceaccount.SCCCache{}}
 	saBackupPlugin.UpdatedForBackup = make(map[string]bool)
 	// we need to create a dependency between scc and service accounts. Service accounts are listed in SCC's users list.
 	saBackupPlugin.SCCMap = make(map[string]map[string][]apisecurity.SecurityContextConstraints)
@@ -185,7 +185,7 @@ func newServiceAccountBackupPlugin(logger logrus.FieldLogger) (interface{}, erro
 }
 
 func newServiceAccountIBAPlugin(logger logrus.FieldLogger) (interface{}, error) {
-	saPlugin := &serviceaccount.IBAPlugin{Log: logger}
+	saPlugin := &serviceaccount.IBAPlugin{Log: logger, SCCCache: &serviceaccount.SCCCache{}}
 	saPlugin.UpdatedForBackup = make(map[string]bool)
 	// we need to create a dependency between scc and service accounts. Service accounts are listed in SCC's users list.
 	saPlugin.SCCMap = make(map[string]map[string][]apisecurity.SecurityContextConstraints)

--- a/velero-plugins/serviceaccount/backup.go
+++ b/velero-plugins/serviceaccount/backup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
 	apisecurity "github.com/openshift/api/security/v1"
@@ -20,12 +21,13 @@ import (
 // BackupPlugin is a backup item action plugin for Velero.
 type BackupPlugin struct {
 	Log logrus.FieldLogger
-	sccCache
+	*SCCCache
 }
 
-type sccCache struct {
+type SCCCache struct {
 	SCCMap           map[string]map[string][]apisecurity.SecurityContextConstraints
 	UpdatedForBackup map[string]bool
+	lock             sync.Mutex
 }
 
 // AppliesTo returns a velero.ResourceSelector that applies to everything.
@@ -42,11 +44,13 @@ var securityClientError error
 // Execute copies local registry images into migration registry
 func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
 	p.Log.Info("[serviceaccount-backup] Entering ServiceAccount backup plugin")
-	additionalItems, err := sccsForSA(p.Log, item, backup, p.sccCache)
+	additionalItems, err := sccsForSA(p.Log, item, backup, p.SCCCache)
 	return item, additionalItems, err
 }
 
-func sccsForSA(log logrus.FieldLogger, item runtime.Unstructured, backup *v1.Backup, cache sccCache) ([]velero.ResourceIdentifier, error) {
+func sccsForSA(log logrus.FieldLogger, item runtime.Unstructured, backup *v1.Backup, cache *SCCCache) ([]velero.ResourceIdentifier, error) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
 	if !cache.UpdatedForBackup[backup.Name] {
 		err := cache.UpdateSCCMap()
 		if err != nil {
@@ -78,7 +82,7 @@ func sccsForSA(log logrus.FieldLogger, item runtime.Unstructured, backup *v1.Bac
 }
 
 // UpdateSCCMap fill scc map with service account as key and SCCs slice as value
-func (c *sccCache) UpdateSCCMap() error {
+func (c *SCCCache) UpdateSCCMap() error {
 	sClient, err := SecurityClient()
 	if err != nil {
 		return err

--- a/velero-plugins/serviceaccount/itemblock.go
+++ b/velero-plugins/serviceaccount/itemblock.go
@@ -10,7 +10,7 @@ import (
 // IBAPlugin is an ItemBlock action plugin for Velero.
 type IBAPlugin struct {
 	Log logrus.FieldLogger
-	sccCache
+	*SCCCache
 }
 
 // AppliesTo returns a velero.ResourceSelector that applies to everything.
@@ -23,7 +23,7 @@ func (p *IBAPlugin) AppliesTo() (velero.ResourceSelector, error) {
 // GetRelatedItems returns a list of SCCs related to this ServiceAccount
 func (p *IBAPlugin) GetRelatedItems(item runtime.Unstructured, backup *v1.Backup) ([]velero.ResourceIdentifier, error) {
 	p.Log.Info("[serviceaccount-iba] Entering ServiceAccount ItemBlock plugin")
-	return sccsForSA(p.Log, item, backup, p.sccCache)
+	return sccsForSA(p.Log, item, backup, p.SCCCache)
 }
 
 // This won't be called but is needed to implement interface


### PR DESCRIPTION
Now that velero can back up multiple items in the same backup concurrently, the SCC map in the ServiceAccount BIA needs to synchronize access. With the prior code, it was possible under certain circumstances for the plugin to crash, if the first two SAs are backed up at the same time and both concurrent plugin execute actions attempt to populate the map at the same time.

This PR adds a Mutex to synchronize access to this map.