### PR TITLE
Fix setup-envtest error by syncing envtest setup with oadp-operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .go/
 _output/
 .idea/
+bin/

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,16 @@ endif
 container:
 	docker build -t $(IMAGE) . $(DOCKER_BUILD_ARGS)
 
+ENVTEST_K8S_VERSION = 1.32 # Kubernetes version from OpenShift 4.19.x
+
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+LOCALBIN ?= $(PROJECT_DIR)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)"
+
 test: envtest
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test -installsuffix "static" -tags $(BUILDTAGS) ./velero-plugins/...
 
@@ -63,23 +73,26 @@ ci: all test
 clean:
 	rm -rf .go _output
 
-GOPATH:=$(shell go env GOPATH)
-GOBIN:=$(GOPATH)/bin
-GOSRC:=$(GOPATH)/src
-#  if KUBEBUILDER_ASSETS contains space, escape it
-KUBEBUILDER_ASSETS=$(shell echo $(shell $(GOBIN)/setup-envtest use -p path) | sed 's/ /\\ /g')
-.PHONY: envtest
 # When debugging tests in vscode, this is example content of .vscode/settings.json
 # which is the output of `setup-envtest use -p path`
 # {
 #     "go.testEnvVars": {
-#         "KUBEBUILDER_ASSETS": "/Users/tiger/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64"
+#         "KUBEBUILDER_ASSETS": "/Users/tiger/Library/Application Support/io.kubebuilder.envtest/k8s/1.32.0-linux-amd64"
 #     }
 # }
-envtest: $(GOBIN)/setup-envtest
-	$(GOBIN)/setup-envtest use -p path
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86)
 
-$(GOBIN)/setup-envtest:
-	@echo Installing envtest tools
-	GOFLAGS= go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6
-	@echo Installed envtest tools
+define go-install-tool
+[ -f $(1) ] || { \
+set -e ;\
+TMP_DIR=$$(mktemp -d) ;\
+cd $$TMP_DIR ;\
+go mod init tmp ;\
+echo "Downloading $(2)" ;\
+GOBIN=$(PROJECT_DIR)/bin go install -mod=mod $(2) ;\
+rm -rf $$TMP_DIR ;\
+}
+endef


### PR DESCRIPTION
Fix setup-envtest GCS 401 error by syncing envtest setup with oadp-operator

The old setup-envtest version downloaded kubebuilder binaries from GCS, which now requires authentication. Update to the same version and pattern used by oadp-operator: install setup-envtest into a project-local bin/ directory, pin ENVTEST_K8S_VERSION to 1.32, and use the go-install-tool macro for conditional installation.

### Before fix (from the prow CI):

```shell
Installing envtest tools
GOFLAGS= go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20240320141353-395cfc7486e6
go: downloading sigs.k8s.io/controller-runtime v0.0.0-20240320141353-395cfc7486e6
go: downloading go.uber.org/zap v1.26.0
go: downloading github.com/go-logr/logr v1.2.4
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/go-logr/zapr v1.2.4
go: downloading github.com/spf13/afero v1.6.0
go: downloading golang.org/x/text v0.12.0
go: downloading go.uber.org/multierr v1.10.0
Installed envtest tools
/go/bin/setup-envtest use -p path
unable to list versions to find latest one: unable list bucket items -- got status "401 Unauthorized" from GCS
make: *** [Makefile:80: envtest] Error 2
```

### Before/After fix (local env):
```shell
# Before fix
$ make test
/home/migi/go/bin/setup-envtest use -p path
unable to list versions to find latest one: unable list bucket items -- got status "401 Unauthorized" from GCS
make: *** [Makefile:80: envtest] Error 2

# Afer fix
$ make test
mkdir -p /home/migi/Development/Upstream/OADP/mpryc-openshift-velero-plugin/bin
[ -f /home/migi/Development/Upstream/OADP/mpryc-openshift-velero-plugin/bin/setup-envtest ] || { set -e ; TMP_DIR=$(mktemp -d) ; cd $TMP_DIR ; go mod init tmp ; echo "Downloading sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86" ; GOBIN=/home/migi/Development/Upstream/OADP/mpryc-openshift-velero-plugin/bin go install -mod=mod sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86 ; rm -rf $TMP_DIR ; }
go: creating new go.mod: module tmp
Downloading sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86
KUBEBUILDER_ASSETS="/home/migi/Development/Upstream/OADP/mpryc-openshift-velero-plugin/bin/k8s/1.32.0-linux-amd64" go test -installsuffix "static" -tags "containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp exclude_graphdriver_overlay include_gcs include_oss" ./velero-plugins/...
?   	github.com/konveyor/openshift-velero-plugin/velero-plugins	[no test files]
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/build	4.912s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/buildconfig	0.067s
?   	github.com/konveyor/openshift-velero-plugin/velero-plugins/clients	[no test files]
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/clusterrolebindings	0.008s
?   	github.com/konveyor/openshift-velero-plugin/velero-plugins/common	[no test files]
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap	0.056s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/cronjob	0.058s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/daemonset	0.027s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/deployment	0.038s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/deploymentconfig	0.038s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/horizontalpodautoscaler	0.006s
?   	github.com/konveyor/openshift-velero-plugin/velero-plugins/imagecopy	[no test files]
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/imagestream	11.197s
?   	github.com/konveyor/openshift-velero-plugin/velero-plugins/imagestreamtag	[no test files]
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/imagetag	0.004s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/job	0.084s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/nonadmin	0.011s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/persistentvolume	0.091s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/pod	0.075s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/pvc	0.035s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/replicaset	0.033s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/replicationcontroller	0.032s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/rolebindings	0.006s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/route	0.006s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/scc	0.005s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/secret	0.005s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/service	0.006s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/serviceaccount	0.013s
ok  	github.com/konveyor/openshift-velero-plugin/velero-plugins/statefulset	0.024s
?   	github.com/konveyor/openshift-velero-plugin/velero-plugins/util/openshift	[no test files]
?   	github.com/konveyor/openshift-velero-plugin/velero-plugins/util/test	[no test files]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build and testing infrastructure with new testing framework integration.
  * Updated project configuration for build artifact management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->