### PR TITLE
OADP-6693: Propagate reclaim space schedule annotation to restored PVCs

### DIFF
--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -120,6 +120,17 @@ const (
 	InitContainerRestoreHookAnnotation string = "init.hook.restore.velero.io/container-image"
 )
 
+// Reclaim space annotations for CSI-Addons/ODF integration.
+// Users set ReclaimSpaceScheduleAnnotation on the Restore CR with a cron schedule
+// (e.g. "@weekly"). The PVC restore plugin propagates this as
+// CSIAddonsReclaimSpaceScheduleAnnotation on each restored PVC, which the
+// CSI-Addons controller (shipped with ODF) uses to create a ReclaimSpaceCronJob
+// that runs rbd sparsify automatically. No-op when CSI-Addons is not installed.
+const (
+	ReclaimSpaceScheduleAnnotation         string = "oadp.openshift.io/reclaim-space-schedule"         // set on Restore CR
+	CSIAddonsReclaimSpaceScheduleAnnotation string = "reclaimspace.csiaddons.openshift.io/schedule"     // set on restored PVCs
+)
+
 // OVN-Kubernetes and Multus CNI-injected annotations.
 // These contain pod-specific networking state (IPs, MAC addresses, gateway
 // routes) that are managed by the CNI and must not be restored. The CNI

--- a/velero-plugins/pvc/restore.go
+++ b/velero-plugins/pvc/restore.go
@@ -24,7 +24,17 @@ func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 // Execute action for the restore plugin for the pvc resource
 func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 
-	if input.Restore.Labels[common.MigrationApplicationLabelKey] != common.MigrationApplicationLabelValue {
+	// Check if the user opted in to automatic space reclamation on restored PVCs.
+	// When set on the Restore CR, this schedule is propagated to each PVC so that
+	// the CSI-Addons controller (ODF) can create a ReclaimSpaceCronJob for it.
+	var reclaimSpaceSchedule string
+	if input.Restore.Annotations != nil {
+		reclaimSpaceSchedule = input.Restore.Annotations[common.ReclaimSpaceScheduleAnnotation]
+	}
+
+	isMigration := input.Restore.Labels[common.MigrationApplicationLabelKey] == common.MigrationApplicationLabelValue
+
+	if !isMigration && reclaimSpaceSchedule == "" {
 		p.Log.Info("[pvc-restore] Returning pvc object as is since this is not a migration activity")
 		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 	}
@@ -36,32 +46,44 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	json.Unmarshal(itemMarshal, &pvc)
 	p.Log.Infof("[pvc-restore] pvc: %s", pvc.Name)
 
-	// Use default behavior (restore the PV) for a swing migration.
-	// For copy we remove annotations and PV volumeName
-	if pvc.Annotations[common.MigrateTypeAnnotation] == common.PvCopyAction {
-
-		// Skip the PVC if this is a stage restore for a stage migration *and* it's a snapshot copy
-		// since snapshot restore is not incremental
-		if input.Restore.Annotations[common.StageOrFinalMigrationAnnotation] == common.StageMigration &&
-			len(input.Restore.Labels[common.StageRestoreLabel]) > 0 &&
-			pvc.Annotations[common.MigrateCopyMethodAnnotation] == common.PvSnapshotCopyMethod {
-			p.Log.Infof("[pvc-restore] skipping restore of pv %s, snapshot PVCs restored only on final migration", pvc.Name)
-			return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
+	// Propagate the reclaim space schedule to the PVC for CSI-Addons to pick up.
+	// Applied for both migration and non-migration (e.g. DataMover) restores.
+	if reclaimSpaceSchedule != "" {
+		if pvc.Annotations == nil {
+			pvc.Annotations = make(map[string]string)
 		}
-		// ISSUE-61 : removing the label selectors from PVC's
-		// to avoid PV dynamic provisioner getting stuck
-		pvc.Spec.Selector = nil
-		storageClassName := pvc.Annotations[common.MigrateStorageClassAnnotation]
-		pvc.Spec.StorageClassName = &storageClassName
-		if pvc.Annotations[corev1API.BetaStorageClassAnnotation] != "" {
-			pvc.Annotations[corev1API.BetaStorageClassAnnotation] = storageClassName
-		}
-		accessMode := pvc.Annotations[common.MigrateAccessModeAnnotation]
-		if accessMode != "" {
-			pvc.Spec.AccessModes = []corev1API.PersistentVolumeAccessMode{corev1API.PersistentVolumeAccessMode(accessMode)}
-		}
+		pvc.Annotations[common.CSIAddonsReclaimSpaceScheduleAnnotation] = reclaimSpaceSchedule
+		p.Log.Infof("[pvc-restore] added reclaim space schedule %s to pvc %s", reclaimSpaceSchedule, pvc.Name)
 	}
-	delete(pvc.Annotations, common.PVCSelectedNodeAnnotation)
+
+	if isMigration {
+		// Use default behavior (restore the PV) for a swing migration.
+		// For copy we remove annotations and PV volumeName
+		if pvc.Annotations[common.MigrateTypeAnnotation] == common.PvCopyAction {
+
+			// Skip the PVC if this is a stage restore for a stage migration *and* it's a snapshot copy
+			// since snapshot restore is not incremental
+			if input.Restore.Annotations[common.StageOrFinalMigrationAnnotation] == common.StageMigration &&
+				len(input.Restore.Labels[common.StageRestoreLabel]) > 0 &&
+				pvc.Annotations[common.MigrateCopyMethodAnnotation] == common.PvSnapshotCopyMethod {
+				p.Log.Infof("[pvc-restore] skipping restore of pv %s, snapshot PVCs restored only on final migration", pvc.Name)
+				return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
+			}
+			// ISSUE-61 : removing the label selectors from PVC's
+			// to avoid PV dynamic provisioner getting stuck
+			pvc.Spec.Selector = nil
+			storageClassName := pvc.Annotations[common.MigrateStorageClassAnnotation]
+			pvc.Spec.StorageClassName = &storageClassName
+			if pvc.Annotations[corev1API.BetaStorageClassAnnotation] != "" {
+				pvc.Annotations[corev1API.BetaStorageClassAnnotation] = storageClassName
+			}
+			accessMode := pvc.Annotations[common.MigrateAccessModeAnnotation]
+			if accessMode != "" {
+				pvc.Spec.AccessModes = []corev1API.PersistentVolumeAccessMode{corev1API.PersistentVolumeAccessMode(accessMode)}
+			}
+		}
+		delete(pvc.Annotations, common.PVCSelectedNodeAnnotation)
+	}
 
 	var out map[string]interface{}
 	objrec, _ := json.Marshal(pvc)

--- a/velero-plugins/pvc/restore_test.go
+++ b/velero-plugins/pvc/restore_test.go
@@ -46,6 +46,216 @@ func TestExecuteForNonMigration(t *testing.T) {
 	assert.Equal(t, item, output.UpdatedItem)
 }
 
+func TestExecuteReclaimSpaceAnnotationNonMigration(t *testing.T) {
+	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
+
+	item := &unstructured.Unstructured{}
+	item.SetAPIVersion("v1")
+	item.SetKind("PersistentVolumeClaim")
+	item.SetNamespace("test-ns")
+	item.SetName("test-pvc")
+
+	input := &velero.RestoreItemActionExecuteInput{
+		Item: item,
+		Restore: &velerov1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+				Annotations: map[string]string{
+					common.ReclaimSpaceScheduleAnnotation: "@weekly",
+				},
+			},
+		},
+	}
+
+	output, err := restorePlugin.Execute(input)
+	require.NoError(t, err)
+	assert.False(t, output.SkipRestore)
+
+	pvcOut := output.UpdatedItem.(*unstructured.Unstructured)
+	annotations := pvcOut.GetAnnotations()
+	assert.Equal(t, "@weekly", annotations[common.CSIAddonsReclaimSpaceScheduleAnnotation])
+}
+
+func TestExecuteReclaimSpaceAnnotationMigration(t *testing.T) {
+	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
+
+	item := &unstructured.Unstructured{}
+	item.SetAPIVersion("v1")
+	item.SetKind("PersistentVolumeClaim")
+	item.SetNamespace("test-ns")
+	item.SetName("test-pvc")
+
+	input := &velero.RestoreItemActionExecuteInput{
+		Item: item,
+		Restore: &velerov1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					common.MigrationApplicationLabelKey: common.MigrationApplicationLabelValue,
+				},
+				Annotations: map[string]string{
+					common.ReclaimSpaceScheduleAnnotation: "@daily",
+				},
+			},
+		},
+	}
+
+	output, err := restorePlugin.Execute(input)
+	require.NoError(t, err)
+	assert.False(t, output.SkipRestore)
+
+	pvcOut := output.UpdatedItem.(*unstructured.Unstructured)
+	annotations := pvcOut.GetAnnotations()
+	assert.Equal(t, "@daily", annotations[common.CSIAddonsReclaimSpaceScheduleAnnotation])
+}
+
+func TestExecuteNoReclaimSpaceAnnotation(t *testing.T) {
+	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
+
+	item := &unstructured.Unstructured{}
+	item.SetAPIVersion("v1")
+	item.SetKind("PersistentVolumeClaim")
+	item.SetNamespace("test-ns")
+	item.SetName("test-pvc")
+
+	input := &velero.RestoreItemActionExecuteInput{
+		Item: item,
+		Restore: &velerov1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      map[string]string{},
+				Annotations: nil,
+			},
+		},
+	}
+
+	output, err := restorePlugin.Execute(input)
+	require.NoError(t, err)
+	assert.False(t, output.SkipRestore)
+	assert.Equal(t, item, output.UpdatedItem)
+}
+
+func TestExecuteReclaimSpacePreservesExistingAnnotations(t *testing.T) {
+	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
+
+	item := &unstructured.Unstructured{}
+	item.SetAPIVersion("v1")
+	item.SetKind("PersistentVolumeClaim")
+	item.SetNamespace("test-ns")
+	item.SetName("test-pvc")
+	item.SetAnnotations(map[string]string{
+		"existing-annotation": "existing-value",
+	})
+
+	input := &velero.RestoreItemActionExecuteInput{
+		Item: item,
+		Restore: &velerov1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+				Annotations: map[string]string{
+					common.ReclaimSpaceScheduleAnnotation: "@weekly",
+				},
+			},
+		},
+	}
+
+	output, err := restorePlugin.Execute(input)
+	require.NoError(t, err)
+
+	pvcOut := output.UpdatedItem.(*unstructured.Unstructured)
+	annotations := pvcOut.GetAnnotations()
+	assert.Equal(t, "@weekly", annotations[common.CSIAddonsReclaimSpaceScheduleAnnotation])
+	assert.Equal(t, "existing-value", annotations["existing-annotation"])
+}
+
+func TestExecuteReclaimSpaceOnPVCWithNoAnnotations(t *testing.T) {
+	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
+
+	item := &unstructured.Unstructured{}
+	item.SetAPIVersion("v1")
+	item.SetKind("PersistentVolumeClaim")
+	item.SetNamespace("test-ns")
+	item.SetName("test-pvc")
+
+	input := &velero.RestoreItemActionExecuteInput{
+		Item: item,
+		Restore: &velerov1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+				Annotations: map[string]string{
+					common.ReclaimSpaceScheduleAnnotation: "@daily",
+				},
+			},
+		},
+	}
+
+	output, err := restorePlugin.Execute(input)
+	require.NoError(t, err)
+
+	pvcOut := output.UpdatedItem.(*unstructured.Unstructured)
+	annotations := pvcOut.GetAnnotations()
+	assert.Equal(t, "@daily", annotations[common.CSIAddonsReclaimSpaceScheduleAnnotation])
+}
+
+func TestExecuteEmptyReclaimSpaceScheduleIsNoop(t *testing.T) {
+	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
+
+	item := &unstructured.Unstructured{}
+	item.SetAPIVersion("v1")
+	item.SetKind("PersistentVolumeClaim")
+	item.SetNamespace("test-ns")
+	item.SetName("test-pvc")
+
+	input := &velero.RestoreItemActionExecuteInput{
+		Item: item,
+		Restore: &velerov1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+				Annotations: map[string]string{
+					common.ReclaimSpaceScheduleAnnotation: "",
+				},
+			},
+		},
+	}
+
+	output, err := restorePlugin.Execute(input)
+	require.NoError(t, err)
+	assert.False(t, output.SkipRestore)
+	assert.Equal(t, item, output.UpdatedItem)
+}
+
+func TestExecuteStageSnapshotSkipWithReclaimSpace(t *testing.T) {
+	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
+
+	item := &unstructured.Unstructured{}
+	item.SetAPIVersion("v1")
+	item.SetKind("PersistentVolumeClaim")
+	item.SetNamespace("test-ns")
+	item.SetName("test-pvc")
+	item.SetAnnotations(map[string]string{
+		common.MigrateTypeAnnotation:       common.PvCopyAction,
+		common.MigrateCopyMethodAnnotation: common.PvSnapshotCopyMethod,
+	})
+
+	input := &velero.RestoreItemActionExecuteInput{
+		Item: item,
+		Restore: &velerov1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					common.MigrationApplicationLabelKey: common.MigrationApplicationLabelValue,
+					common.StageRestoreLabel:            "true",
+				},
+				Annotations: map[string]string{
+					common.StageOrFinalMigrationAnnotation: common.StageMigration,
+					common.ReclaimSpaceScheduleAnnotation:  "@weekly",
+				},
+			},
+		},
+	}
+
+	output, err := restorePlugin.Execute(input)
+	require.NoError(t, err)
+	assert.True(t, output.SkipRestore)
+}
+
 func TestExecuteSkipsSnapshotPVCOnStageRestore(t *testing.T) {
 	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
 


### PR DESCRIPTION
## Summary
- When users set `oadp.openshift.io/reclaim-space-schedule` on a Restore CR (e.g. `@weekly`), the PVC restore plugin now propagates it as `reclaimspace.csiaddons.openshift.io/schedule` on each restored PVC
- The CSI-Addons controller (shipped with ODF) picks this up and creates a `ReclaimSpaceCronJob` that runs `rbd sparsify` automatically, eliminating manual space reclamation after DataMover restores
- The annotation is opt-in and a no-op on clusters without CSI-Addons installed

## Changes
- `velero-plugins/common/types.go` — Added `ReclaimSpaceScheduleAnnotation` and `CSIAddonsReclaimSpaceScheduleAnnotation` constants
- `velero-plugins/pvc/restore.go` — Read the schedule from `input.Restore.Annotations` and set it on the PVC; works for both migration and non-migration restores
- `velero-plugins/pvc/restore_test.go` — Added 7 new test cases covering: non-migration propagation, migration propagation, nil annotations safety, existing annotation preservation, nil PVC annotations initialization, empty schedule no-op, and stage snapshot skip interaction

## Usage
```yaml
apiVersion: velero.io/v1
kind: Restore
metadata:
  annotations:
    oadp.openshift.io/reclaim-space-schedule: "@weekly"
spec:
  backupName: my-backup
```

## Test plan
- [x] All 10 PVC restore plugin tests pass
- [x] Full test suite passes (pre-existing `build` and `imagestream` failures unrelated — missing local kubebuilder/etcd binaries)

Fixes: [OADP-6693](https://issues.redhat.com/browse/OADP-6693)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reclaim-space scheduling on Restore operations. Users can now specify a cron schedule annotation that will be automatically propagated to restored PVCs for CSI-Addons/ODF integration, enabling automatic reclaim-space operations on both migration and non-migration restores.

* **Tests**
  * Added comprehensive test coverage for reclaim-space scheduling behavior across migration and non-migration restore scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->