### PR TITLE
fix: mock GetBucketRegion in shared_test.go

### DIFF
--- a/velero-plugins/imagestream/shared_test.go
+++ b/velero-plugins/imagestream/shared_test.go
@@ -167,6 +167,13 @@ func TestGetRegistryEnvsForLocation(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer testEnv.Stop()
+
+	originalGetBucketRegionFunc := GetBucketRegionFunc
+	GetBucketRegionFunc = func(bucket string) (string, error) {
+		return "us-east-2", nil
+	}
+	defer func() { GetBucketRegionFunc = originalGetBucketRegionFunc }()
+
 	clients.SetInClusterConfig(cfg)
 	client, err := dynamic.NewForConfig(cfg)
 	if err != nil {


### PR DESCRIPTION
## Summary

`TestGetRegistryEnvsForLocation` in `shared_test.go` was hitting real S3 to determine bucket region, causing CI failures when no AWS credentials are available. Mock `GetBucketRegionFunc` the same way `s3_test.go` and `registry_test.go` already do (via PR #365).

Also fixes `wantErrString` to match the full wrapped error from `GetRegistryEnvsForLocation`.

## Other branches

This fix is also included in:
- oadp-1.6: #403
- oadp-1.5: #404
- oadp-1.4: #405

🤖 Generated with [Claude Code](https://claude.ai/code)