### PR TITLE
OADP-8223: Strip OVN-K and Multus CNI annotations during pod restore

### DIFF
--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -114,3 +114,21 @@ const (
 	//InitContainer restore hook must contain this annotation
 	InitContainerRestoreHookAnnotation string = "init.hook.restore.velero.io/container-image"
 )
+
+// OVN-Kubernetes and Multus CNI-injected annotations.
+// These contain pod-specific networking state (IPs, MAC addresses, gateway
+// routes) that are managed by the CNI and must not be restored. The CNI
+// will re-inject correct values when the pod is created.
+const (
+	OVNPodNetworksAnnotation       string = "k8s.ovn.org/pod-networks"
+	MultusNetworkStatusAnnotation  string = "k8s.v1.cni.cncf.io/network-status"
+	MultusNetworksStatusAnnotation string = "k8s.v1.cni.cncf.io/networks-status"
+)
+
+// CNIAnnotationsToStrip is the list of CNI-injected annotations to remove
+// from pods during restore.
+var CNIAnnotationsToStrip = []string{
+	OVNPodNetworksAnnotation,
+	MultusNetworkStatusAnnotation,
+	MultusNetworksStatusAnnotation,
+}

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -308,6 +308,18 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 			pod.Spec.Containers[n].VolumeMounts = volumeMount
 		}
 	}
+	// Strip CNI-injected annotations (OVN-K, Multus) that contain
+	// pod-specific networking state. The CNI will re-inject correct
+	// values when the pod is created.
+	if pod.Annotations != nil {
+		for _, annotation := range common.CNIAnnotationsToStrip {
+			if _, exists := pod.Annotations[annotation]; exists {
+				p.Log.Infof("[pod-restore] stripping CNI annotation %s from pod %s", annotation, pod.Name)
+				delete(pod.Annotations, annotation)
+			}
+		}
+	}
+
 	var out map[string]interface{}
 	objrec, _ := json.Marshal(pod)
 	json.Unmarshal(objrec, &out)

--- a/velero-plugins/pod/restore_test.go
+++ b/velero-plugins/pod/restore_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1API "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,6 +167,73 @@ func TestRestorePlugin_podHasRestoreHooks(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("RestorePlugin.podHasRestoreHooks() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestStripCNIAnnotations(t *testing.T) {
+	tests := []struct {
+		name                string
+		annotations         map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name:                "pod with no annotations",
+			annotations:         nil,
+			expectedAnnotations: nil,
+		},
+		{
+			name: "pod with all CNI annotations",
+			annotations: map[string]string{
+				common.OVNPodNetworksAnnotation:      `{"default":{"ip_addresses":["10.129.2.14/23"]}}`,
+				common.MultusNetworkStatusAnnotation:  `[{"name":"ovn-kubernetes","interface":"eth0"}]`,
+				common.MultusNetworksStatusAnnotation: `[{"name":"ovn-kubernetes","interface":"eth0"}]`,
+				"app": "test",
+			},
+			expectedAnnotations: map[string]string{
+				"app": "test",
+			},
+		},
+		{
+			name: "pod with only OVN-K annotation",
+			annotations: map[string]string{
+				common.OVNPodNetworksAnnotation: `{"default":{"ip_addresses":["10.129.2.14/23"]}}`,
+				"app":                           "test",
+			},
+			expectedAnnotations: map[string]string{
+				"app": "test",
+			},
+		},
+		{
+			name: "pod with no CNI annotations",
+			annotations: map[string]string{
+				"app":     "test",
+				"version": "v1",
+			},
+			expectedAnnotations: map[string]string{
+				"app":     "test",
+				"version": "v1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := corev1API.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pod",
+					Namespace:   "test-ns",
+					Annotations: tt.annotations,
+				},
+			}
+
+			if pod.Annotations != nil {
+				for _, annotation := range common.CNIAnnotationsToStrip {
+					delete(pod.Annotations, annotation)
+				}
+			}
+
+			assert.Equal(t, tt.expectedAnnotations, pod.Annotations)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Cherry-pick of #389 to `oadp-1.4`
- Strip OVN-K (`k8s.ovn.org/pod-networks`) and Multus (`k8s.v1.cni.cncf.io/network-status`, `k8s.v1.cni.cncf.io/networks-status`) annotations from pods during restore
- These annotations contain pod-specific networking state (IPs, MAC addresses, gateway routes) managed by the CNI. Restoring stale values causes networking issues since the CNI must re-inject correct values when the pod is created

Fixes: https://issues.redhat.com/browse/OADP-8223

🤖 Generated with [Claude Code](https://claude.com/claude-code)