### PR TITLE
Update setup-envtest to release-0.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,16 @@ DOCKER_BUILD_ARGS ?= --platform=linux/amd64
 container:
 	docker build -t $(IMAGE) . $(DOCKER_BUILD_ARGS)
 
+ENVTEST_K8S_VERSION = 1.27 # Kubernetes version from k8s.io/api v0.27.x
+
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+LOCALBIN ?= $(PROJECT_DIR)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)"
+
 test: envtest
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test -installsuffix "static" -tags $(BUILDTAGS) ./velero-plugins/...
 
@@ -57,23 +67,26 @@ ci: all test
 clean:
 	rm -rf .go _output
 
-GOPATH:=$(shell go env GOPATH)
-GOBIN:=$(GOPATH)/bin
-GOSRC:=$(GOPATH)/src
-#  if KUBEBUILDER_ASSETS contains space, escape it
-KUBEBUILDER_ASSETS=$(shell echo $(shell $(GOBIN)/setup-envtest use -p path) | sed 's/ /\\ /g')
-.PHONY: envtest
 # When debugging tests in vscode, this is example content of .vscode/settings.json
 # which is the output of `setup-envtest use -p path`
 # {
 #     "go.testEnvVars": {
-#         "KUBEBUILDER_ASSETS": "/Users/tiger/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64"
+#         "KUBEBUILDER_ASSETS": "/Users/tiger/Library/Application Support/io.kubebuilder.envtest/k8s/1.27.0-linux-amd64"
 #     }
 # }
-envtest: $(GOBIN)/setup-envtest
-	$(GOBIN)/setup-envtest use -p path
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22)
 
-$(GOBIN)/setup-envtest:
-	@echo Installing envtest tools
-	GOFLAGS= go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6
-	@echo Installed envtest tools
+define go-install-tool
+[ -f $(1) ] || { \
+set -e ;\
+TMP_DIR=$$(mktemp -d) ;\
+cd $$TMP_DIR ;\
+go mod init tmp ;\
+echo "Downloading $(2)" ;\
+GOBIN=$(PROJECT_DIR)/bin go install -mod=mod $(2) ;\
+rm -rf $$TMP_DIR ;\
+}
+endef

--- a/velero-plugins/imagestream/registry_test.go
+++ b/velero-plugins/imagestream/registry_test.go
@@ -2,6 +2,7 @@ package imagestream
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 )
 
 const (
+	DiscoverableBucket     = "tkaovila-aug30-velero-bsl"
 	testProfile            = "someProfile"
 	testAccessKey          = "someAccessKey"
 	testSecretAccessKey    = "someSecretAccessKey"
@@ -201,7 +203,7 @@ func Test_getAWSRegistryEnvVars(t *testing.T) {
 					Provider: AWSProvider,
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
-							Bucket: "tkaovila-aug30-velero-bsl",
+							Bucket: DiscoverableBucket,
 						},
 					},
 					Config: map[string]string{
@@ -230,7 +232,7 @@ func Test_getAWSRegistryEnvVars(t *testing.T) {
 				},
 				{
 					Name:  RegistryStorageS3BucketEnvVarKey,
-					Value: "tkaovila-aug30-velero-bsl",
+					Value: DiscoverableBucket,
 				},
 				{
 					Name:  RegistryStorageS3RegionEnvVarKey,
@@ -412,6 +414,15 @@ func Test_getAWSRegistryEnvVars(t *testing.T) {
 	}
 	defer testEnv.Stop()
 	clients.SetInClusterConfig(cfg)
+	originalGetBucketRegionFunc := GetBucketRegionFunc
+	GetBucketRegionFunc = func(bucket string) (string, error) {
+		if bucket == DiscoverableBucket {
+			return "us-east-1", nil
+		}
+		return "", fmt.Errorf("bucket region not discoverable")
+	}
+	defer func() { GetBucketRegionFunc = originalGetBucketRegionFunc }()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cv1c, err := corev1client.NewForConfig(cfg)

--- a/velero-plugins/imagestream/s3.go
+++ b/velero-plugins/imagestream/s3.go
@@ -9,9 +9,17 @@ import (
 	"github.com/pkg/errors"
 )
 
+// GetBucketRegionFunc is the function used to get bucket region.
+// It can be replaced in tests for mocking.
+var GetBucketRegionFunc = getBucketRegionImpl
+
 // GetBucketRegion returns the AWS region that a bucket is in, or an error
-// if the region cannot be determined.
+// if the region cannot be determined. This is a wrapper that calls GetBucketRegionFunc.
 func GetBucketRegion(bucket string) (string, error) {
+	return GetBucketRegionFunc(bucket)
+}
+
+func getBucketRegionImpl(bucket string) (string, error) {
 	var region string
 
 	session, err := session.NewSession()

--- a/velero-plugins/imagestream/s3_test.go
+++ b/velero-plugins/imagestream/s3_test.go
@@ -7,45 +7,65 @@ func TestGetBucketRegion(t *testing.T) {
 		bucket string
 	}
 	tests := []struct {
-		name    string
-		bucket  string
-		want    string
-		wantErr bool
+		name       string
+		bucket     string
+		mockRegion string
+		mockErr    error
+		wantRegion string
+		wantErr    bool
 	}{
 		{
-		  	name: "openshift-velero-plugin-s3-auto-region-test-1",
-				bucket: "openshift-velero-plugin-s3-auto-region-test-1",
-				want: "us-east-1",
-				wantErr: false,
+			name:       "openshift-velero-plugin-s3-auto-region-test-1",
+			bucket:     "openshift-velero-plugin-s3-auto-region-test-1",
+			mockRegion: "us-east-1",
+			mockErr:    nil,
+			wantRegion: "us-east-1",
+			wantErr:    false,
 		},
 		{
-		  	name: "openshift-velero-plugin-s3-auto-region-test-2",
-				bucket: "openshift-velero-plugin-s3-auto-region-test-2",
-				want: "us-west-1",
-				wantErr: false,
+			name:       "openshift-velero-plugin-s3-auto-region-test-2",
+			bucket:     "openshift-velero-plugin-s3-auto-region-test-2",
+			mockRegion: "us-west-1",
+			mockErr:    nil,
+			wantRegion: "us-west-1",
+			wantErr:    false,
 		},
 		{
-		  	name: "openshift-velero-plugin-s3-auto-region-test-3",
-				bucket: "openshift-velero-plugin-s3-auto-region-test-3",
-				want: "eu-central-1",
-				wantErr: false,
+			name:       "openshift-velero-plugin-s3-auto-region-test-3",
+			bucket:     "openshift-velero-plugin-s3-auto-region-test-3",
+			mockRegion: "eu-central-1",
+			mockErr:    nil,
+			wantRegion: "eu-central-1",
+			wantErr:    false,
 		},
 		{
-		  	name: "openshift-velero-plugin-s3-auto-region-test-4",
-				bucket: "openshift-velero-plugin-s3-auto-region-test-4",
-				want: "sa-east-1",
-				wantErr: false,
+			name:       "openshift-velero-plugin-s3-auto-region-test-4",
+			bucket:     "openshift-velero-plugin-s3-auto-region-test-4",
+			mockRegion: "sa-east-1",
+			mockErr:    nil,
+			wantRegion: "sa-east-1",
+			wantErr:    false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			originalFunc := GetBucketRegionFunc
+			defer func() { GetBucketRegionFunc = originalFunc }()
+
+			GetBucketRegionFunc = func(bucket string) (string, error) {
+				if bucket != tt.bucket {
+					t.Errorf("GetBucketRegion called with wrong bucket: got %v, want %v", bucket, tt.bucket)
+				}
+				return tt.mockRegion, tt.mockErr
+			}
+
 			got, err := GetBucketRegion(tt.bucket)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetBucketRegion() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("GetBucketRegion() = %v, want %v", got, tt.want)
+			if got != tt.wantRegion {
+				t.Errorf("GetBucketRegion() = %v, want %v", got, tt.wantRegion)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Updates `setup-envtest` install from the old pinned commit (`v0.0.0-20240320141353-395cfc7486e6`) to `@release-0.22`
- The old version downloads envtest binaries from the kubebuilder GCS bucket which has been [decommissioned](https://github.com/kubernetes/k8s.io/issues/2647) and now returns `401 Unauthorized`, breaking CI unit tests
- The `release-0.22` branch uses the [controller-tools GitHub releases index](https://github.com/kubernetes-sigs/controller-runtime/pull/2811) instead (GCS support was [fully dropped in v0.20](https://github.com/kubernetes-sigs/controller-runtime/pull/2915))

Fixes the unit-test failure in #425.


Made with [Cursor](https://cursor.com)