### PR TITLE
UPSTREAM: <carry>: Migrate HPA plugin from autoscaling/v2beta1 to v2

### DIFF
--- a/velero-plugins/horizontalpodautoscaler/restore.go
+++ b/velero-plugins/horizontalpodautoscaler/restore.go
@@ -7,7 +7,7 @@ import (
 	appsv1API "github.com/openshift/api/apps/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
-	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -26,11 +26,11 @@ func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 // Execute fixes apiVersion in ScaleTargetRef of HPA
 func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	p.Log.Info("[hpa-restore] Entering HorizontalPodAutoscaler restore plugin")
-	hpa := v2beta1.HorizontalPodAutoscaler{}
+	hpa := v2.HorizontalPodAutoscaler{}
 	itemMarshal, _ := json.Marshal(input.Item)
 	json.Unmarshal(itemMarshal, &hpa)
 
-	if (v2beta1.CrossVersionObjectReference{}) != hpa.Spec.ScaleTargetRef {
+	if (v2.CrossVersionObjectReference{}) != hpa.Spec.ScaleTargetRef {
 		gv, err := schema.ParseGroupVersion(hpa.Spec.ScaleTargetRef.APIVersion)
 		if err != nil {
 			p.Log.Error("[hpa-restore] error parsing API version of spec.scaleTargetRef: ", err)

--- a/velero-plugins/horizontalpodautoscaler/restore_test.go
+++ b/velero-plugins/horizontalpodautoscaler/restore_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
-	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -24,14 +24,14 @@ func TestRestorePluginExecute(t *testing.T) {
 		name                   string
 		hpa                    *unstructured.Unstructured
 		expectedAPIVersion     string
-		expectedScaleTargetRef v2beta1.CrossVersionObjectReference
+		expectedScaleTargetRef v2.CrossVersionObjectReference
 		shouldModify           bool
 	}{
 		{
 			name: "HPA with DeploymentConfig and v1 API version should be updated",
 			hpa: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": "autoscaling/v2beta1",
+					"apiVersion": "autoscaling/v2",
 					"kind":       "HorizontalPodAutoscaler",
 					"metadata": map[string]interface{}{
 						"name":      "test-hpa",
@@ -53,7 +53,7 @@ func TestRestorePluginExecute(t *testing.T) {
 			name: "HPA with DeploymentConfig and apps.openshift.io/v1 API version should not be modified",
 			hpa: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": "autoscaling/v2beta1",
+					"apiVersion": "autoscaling/v2",
 					"kind":       "HorizontalPodAutoscaler",
 					"metadata": map[string]interface{}{
 						"name":      "test-hpa",
@@ -75,7 +75,7 @@ func TestRestorePluginExecute(t *testing.T) {
 			name: "HPA with Deployment should not be modified",
 			hpa: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": "autoscaling/v2beta1",
+					"apiVersion": "autoscaling/v2",
 					"kind":       "HorizontalPodAutoscaler",
 					"metadata": map[string]interface{}{
 						"name":      "test-hpa",
@@ -97,7 +97,7 @@ func TestRestorePluginExecute(t *testing.T) {
 			name: "HPA without scaleTargetRef should not be modified",
 			hpa: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": "autoscaling/v2beta1",
+					"apiVersion": "autoscaling/v2",
 					"kind":       "HorizontalPodAutoscaler",
 					"metadata": map[string]interface{}{
 						"name":      "test-hpa",
@@ -112,7 +112,7 @@ func TestRestorePluginExecute(t *testing.T) {
 			name: "HPA with invalid API version should return error",
 			hpa: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": "autoscaling/v2beta1",
+					"apiVersion": "autoscaling/v2",
 					"kind":       "HorizontalPodAutoscaler",
 					"metadata": map[string]interface{}{
 						"name":      "test-hpa",


### PR DESCRIPTION
## Summary

Migrates the HorizontalPodAutoscaler restore plugin from `k8s.io/api/autoscaling/v2beta1` to `k8s.io/api/autoscaling/v2`.

The `autoscaling/v2beta1` package was removed in `k8s.io/api v0.36.0`. The oadp-dev rebase is blocked because the velero dependency now pulls in the newer `k8s.io/api`, and the HPA plugin still imports the removed package. The `autoscaling/v2` API is the stable replacement and is structurally compatible -- `HorizontalPodAutoscaler`, `CrossVersionObjectReference`, and all fields used by the plugin (`Spec.ScaleTargetRef`, `APIVersion`, `Kind`, `Name`) are identical in the v2 API.

Closes https://github.com/openshift/openshift-velero-plugin/issues/446

## Changes

- `velero-plugins/horizontalpodautoscaler/restore.go`: Updated import from `v2beta1` to `v2`, updated all type references (`v2beta1.HorizontalPodAutoscaler` to `v2.HorizontalPodAutoscaler`, `v2beta1.CrossVersionObjectReference` to `v2.CrossVersionObjectReference`)
- `velero-plugins/horizontalpodautoscaler/restore_test.go`: Same import and type reference updates, plus updated test fixture `apiVersion` fields from `autoscaling/v2beta1` to `autoscaling/v2`

## Test plan

- [x] `go build ./velero-plugins/horizontalpodautoscaler/...` compiles cleanly
- [x] `go test ./velero-plugins/horizontalpodautoscaler/...` passes (all 6 test cases)
- [x] `go vet ./velero-plugins/horizontalpodautoscaler/...` reports no issues
- [x] No remaining references to `v2beta1` in the codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Horizontal Pod Autoscaler restoration to support the stable `autoscaling/v2` API.
  * Preserved existing handling for scale target references, including DeploymentConfig targets.
  * Updated restoration validation and expected behavior for the newer API version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->